### PR TITLE
Initial qemu-arm support

### DIFF
--- a/.travis.install.py
+++ b/.travis.install.py
@@ -10,12 +10,14 @@ OS_NAME=os.environ.get('TRAVIS_OS_NAME') or 'linux'
 OS_PMAN={'linux': 'sudo apt-get', 'osx': 'brew'}[OS_NAME]
 
 LAZ_TMP_DIR=os.environ.get('LAZ_TMP_DIR') or 'lazarus_tmp'
-LAZ_REL_DEF=os.environ.get('LAZ_REL_DEF') or {'linux':'amd64', 'osx':'i386', 'wine':'32'}
+LAZ_REL_DEF=os.environ.get('LAZ_REL_DEF') or {'linux':'amd64', 'qemu-arm':'amd64', 'qemu-arm-static':'amd64', 'osx':'i386', 'wine':'32'}
 LAZ_BIN_SRC=os.environ.get('LAZ_BIN_SRC') or 'http://mirrors.iwi.me/lazarus/releases/%(target)s/Lazarus%%20%(version)s'
 LAZ_BIN_TGT=os.environ.get('LAZ_BIN_TGT') or {
-    'linux': 'Lazarus%%20Linux%%20%(release)s%%20DEB',
-    'osx':   'Lazarus%%20Mac%%20OS%%20X%%20%(release)s',
-    'wine':  'Lazarus%%20Windows%%20%(release)s%%20bits'
+    'linux':           'Lazarus%%20Linux%%20%(release)s%%20DEB',
+    'qemu-arm':        'Lazarus%%20Linux%%20%(release)s%%20DEB',
+    'qemu-arm-static': 'Lazarus%%20Linux%%20%(release)s%%20DEB',
+    'osx':             'Lazarus%%20Mac%%20OS%%20X%%20%(release)s',
+    'wine':            'Lazarus%%20Windows%%20%(release)s%%20bits'
 }
 
 def install_osx_dmg(dmg):
@@ -49,42 +51,96 @@ def install_lazarus_default():
     else:
         # Default to lazarus
         pkg = 'lazarus'
-    return os.system('%s update && %s install %s' % (OS_PMAN, OS_PMAN, pkg)) == 0
+    return os.system('%s install %s' % (OS_PMAN, pkg)) == 0
 
-def install_lazarus_version(ver,rel,wine):
-    # Download directory for specified Lazarus version
-    osn = 'wine' if wine else OS_NAME
+def install_lazarus_version(ver,rel,env):
+    # Download all files in directory for specified Lazarus version
+    osn = env or OS_NAME
     tgt = LAZ_BIN_TGT[osn] % {'release': rel or LAZ_REL_DEF[osn]}
     src = LAZ_BIN_SRC % {'target': tgt, 'version': ver}
     if os.system('wget -r -l1 -T 30 -np -nd -nc -A .deb,.dmg,.exe %s -P %s' % (src, LAZ_TMP_DIR)) != 0:
         return False
 
-    if wine:
-        if os.system('%s update && %s install wine && %s wineboot' % (OS_PMAN, OS_PMAN, wine)) != 0:
+    if osn == 'wine':
+        # Install wine and initialize wine directory
+        if os.system('%s install wine && wine wineboot' % (OS_PMAN)) != 0:
             return False
 
-        # Set wine Path (persistently) to include Lazarus binary directory
-        if os.system('%s cmd /C reg add HKEY_CURRENT_USER\\\\Environment /v PATH /t REG_SZ /d %%PATH%%\\;c:\\\\lazarus' % (wine)) != 0:
-            return False;
-
         # Install all .exe files with wine
-        process_file = lambda f: (not f.endswith('.exe')) or os.system('%s %s /VERYSILENT /DIR="c:\\lazarus"' % (wine, f)) == 0
-    elif OS_NAME == 'linux':
+        process_file = lambda f: (not f.endswith('.exe')) or os.system('wine %s /VERYSILENT /DIR="c:\\lazarus"' % (f)) == 0
+    elif osn == 'qemu-arm' or osn == 'qemu-arm-static':
+        # Install qemu and arm cross compiling utilities
+        if os.system('%s install qemu-user qemu-user-static binutils-arm-linux-gnueabi gcc-arm-linux-gnueabi' % (OS_PMAN)) != 0:
+            return False
+
+        # Install all .deb files (for linux) and cross compile later
+        process_file = lambda f: (not f.endswith('.deb')) or os.system('sudo dpkg -i %s' % (f)) == 0
+    elif osn == 'linux':
         # Install all .deb files
         process_file = lambda f: (not f.endswith('.deb')) or os.system('sudo dpkg -i %s' % (f)) == 0
-    elif OS_NAME == 'osx':
+    elif osn == 'osx':
         # Install all .dmg files
         process_file = lambda f: (not f.endswith('.dmg')) or install_osx_dmg(f)
     else:
         return False
 
-    return all(map(lambda f: process_file(os.path.join(LAZ_TMP_DIR, f)), sorted(os.listdir(LAZ_TMP_DIR))))
+    # Process all downloaded files
+    if not all(map(lambda f: process_file(os.path.join(LAZ_TMP_DIR, f)), sorted(os.listdir(LAZ_TMP_DIR)))):
+        return False
 
-def install_lazarus(ver=None,rel=None,wine=None):
-    return install_lazarus_version(ver,rel,wine) if ver else install_lazarus_default()
+    if osn == 'wine':
+        # Set wine Path (persistently) to include Lazarus binary directory
+        if os.system('wine cmd /C reg add HKEY_CURRENT_USER\\\\Environment /v PATH /t REG_SZ /d %%PATH%%\\;c:\\\\lazarus') != 0:
+            return False
+
+        # Redirect listed executables so they execute in wine
+        for alias in ('fpc', 'lazbuild', 'lazarus'):
+            os.system('echo "#!/usr/bin/env bash \nwine %(target)s \$@" | sudo tee %(name)s > /dev/null && sudo chmod +x %(name)s' % {
+                'target': alias,
+                'name': '/usr/bin/%s' % (alias)
+            })
+    elif osn == 'qemu-arm' or osn == 'qemu-arm-static':
+        fpcv = subprocess.check_output('fpc -iV', shell=True).strip()
+        gccv = subprocess.check_output('arm-linux-gnueabi-gcc -dumpversion', shell=True).strip()
+        opts = ' '.join([
+            'CPU_TARGET=arm',
+            'OS_TARGET=linux',
+            'BINUTILSPREFIX=arm-linux-gnueabi-',
+            # 'CROSSOPT="-CpARMV7A -CfVFPV3_D16"',
+            'OPT=-dFPC_ARMEL',
+            'INSTALL_PREFIX=/usr'
+        ])
+
+        # Compile ARM cross compiler
+        if os.system('cd /usr/share/fpcsrc/%s && sudo make clean crossall crossinstall %s' % (fpcv, opts)) != 0:
+            return False
+        
+        # Symbolic link to update default FPC cross compiler for ARM
+        if os.system('sudo ln -sf /usr/lib/fpc/%s/ppcrossarm /usr/bin/ppcarm' % (fpcv)) != 0:
+            return False
+
+        # Update config file with paths to ARM libraries
+        config = '\n'.join([
+            '#INCLUDE /etc/fpc.cfg',
+            '#IFDEF CPUARM',
+            '-Xd','-Xt',
+            '-XParm-linux-gnueabi-',
+            '-Fl/usr/arm-linux-gnueabi/lib',
+            '-Fl/usr/lib/gcc/arm-linux-gnueabi/%s' % (gccv),
+            # '-CpARMV7A', '-CfVFPV3_D16',
+            '#ENDIF'
+        ])
+        with open(os.path.expanduser('~/.fpc.cfg'),'w') as f:
+            f.write(config)
+
+    return True
+
+def install_lazarus(ver=None,rel=None,env=None):
+    return install_lazarus_version(ver,rel,env) if ver else install_lazarus_default()
 
 def main():
-    return install_lazarus(os.environ.get('LAZ_VER'),os.environ.get('LAZ_REL'),os.environ.get('LAZ_WINE'))
+    os.system('%s update' % (OS_PMAN))
+    return install_lazarus(os.environ.get('LAZ_VER'),os.environ.get('LAZ_REL'),os.environ.get('LAZ_ENV'))
 
 if __name__ == '__main__':
     sys.exit(int(not main()))

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,24 +20,28 @@ env:
 matrix:
   include:
     - os: linux
-      env: LAZ_VER=1.0.14 LAZ_WINE=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
+      env: LAZ_VER=1.0.14 LAZ_ENV=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
     - os: linux
-      env: LAZ_VER=1.2.6  LAZ_WINE=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
+      env: LAZ_VER=1.2.6  LAZ_ENV=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
     - os: linux
-      env: LAZ_VER=1.4.4  LAZ_WINE=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
+      env: LAZ_VER=1.4.4  LAZ_ENV=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
     - os: linux
-      env: LAZ_VER=1.2.6  LAZ_WINE=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
+      env: LAZ_VER=1.2.6  LAZ_ENV=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
     - os: linux
-      env: LAZ_VER=1.4.4  LAZ_WINE=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
+      env: LAZ_VER=1.4.4  LAZ_ENV=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
+    - os: linux
+      env: LAZ_VER=1.2.6  LAZ_ENV=qemu-arm LAZ_OPT="--os=linux --cpu=arm --widgetset=nogui"
+    - os: linux
+      env: LAZ_VER=1.4.4  LAZ_ENV=qemu-arm LAZ_OPT="--os=linux --cpu=arm --widgetset=nogui"
 
 before_install:
     # Start virtual display server
   - sh -e /etc/init.d/xvfb start || true
 
 install:
-    # Install prerequisites (wine/fpc/lazarus)
+    # Install prerequisites (fpc/lazarus/wine/qemu)
   - ./.travis.install.py
 
 script:
-  - $LAZ_WINE lazbuild $LAZ_OPT my_lazarus_tests.lpi      # Build my_lazarus_test project
-  - $LAZ_WINE ./bin/my_lazarus_tests --all --format=plain # Run my_lazarus_test testsuite
+  - lazbuild $LAZ_OPT my_lazarus_tests.lpi               # Build my_lazarus_test project
+  - $LAZ_ENV ./bin/my_lazarus_tests --all --format=plain # Run my_lazarus_test testsuite

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ How to use
     matrix:
       include:
         - os: linux
-          env: LAZ_VER=1.4.4 LAZ_WINE=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
+          env: LAZ_VER=1.4.4 LAZ_ENV=wine WINEARCH=win32 LAZ_OPT="--os=win32 --cpu=i386"
         - os: linux
-          env: LAZ_VER=1.4.4 LAZ_WINE=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
+          env: LAZ_VER=1.4.4 LAZ_ENV=wine WINEARCH=win64 LAZ_OPT="--os=win64 --cpu=x86_64"
     ```
-    Note that your run script should take into account that it should run with Wine, for example using `$LAZ_WINE lazbuild $LAZ_OPT`. This also requires a virtual display server, as explained in the next step.
+    Note that your run script should take into account that it should run with Wine, for example using `$LAZ_ENV lazbuild $LAZ_OPT`. This also requires a virtual display server, as explained in the next step.
   - Add a virtual display server if you cannot run headless (_required for Wine_):
 
     ```yaml


### PR DESCRIPTION
Changed `LAZ_WINE` to `LAZ_ENV`. `LAZ_ENV` can be any of `linux`, `osx`, `wine`, `qemu-arm`, `qemu-arm-static`.
