### PR TITLE
Revert "Do not download the 'project' combo packages"

### DIFF
--- a/.travis.install.py
+++ b/.travis.install.py
@@ -11,7 +11,7 @@ OS_PMAN={'linux': 'sudo apt-get', 'osx': 'brew'}[OS_NAME]
 
 LAZ_TMP_DIR=os.environ.get('LAZ_TMP_DIR') or 'lazarus_tmp'
 LAZ_REL_DEF=os.environ.get('LAZ_REL_DEF') or {'linux':'amd64', 'qemu-arm':'amd64', 'qemu-arm-static':'amd64', 'osx':'i386', 'wine':'32'}
-LAZ_BIN_SRC=os.environ.get('LAZ_BIN_SRC') or 'http://mirrors.iwi.me/lazarus/releases/%(target)s/Lazarus%%20%(version)s/'
+LAZ_BIN_SRC=os.environ.get('LAZ_BIN_SRC') or 'http://mirrors.iwi.me/lazarus/releases/%(target)s/Lazarus%%20%(version)s'
 LAZ_BIN_TGT=os.environ.get('LAZ_BIN_TGT') or {
     'linux':           'Lazarus%%20Linux%%20%(release)s%%20DEB',
     'qemu-arm':        'Lazarus%%20Linux%%20%(release)s%%20DEB',
@@ -58,7 +58,7 @@ def install_lazarus_version(ver,rel,env):
     osn = env or OS_NAME
     tgt = LAZ_BIN_TGT[osn] % {'release': rel or LAZ_REL_DEF[osn]}
     src = LAZ_BIN_SRC % {'target': tgt, 'version': ver}
-    if os.system('wget -r -l1 -T 30 -np -nd -nc --accept-regex=".*[.](deb|dmg|exe)$" --reject-regex="project" %s -P %s' % (src, LAZ_TMP_DIR)) != 0:
+    if os.system('wget -r -l1 -T 30 -np -nd -nc -A .deb,.dmg,.exe %s -P %s' % (src, LAZ_TMP_DIR)) != 0:
         return False
 
     if osn == 'wine':
@@ -125,7 +125,7 @@ def install_lazarus_version(ver,rel,env):
         # Compile ARM cross compiler
         if os.system('cd /usr/share/fpcsrc/%s && sudo make clean crossall crossinstall %s' % (fpcv, opts)) != 0:
             return False
-
+        
         # Symbolic link to update default FPC cross compiler for ARM
         if os.system('sudo ln -sf /usr/lib/fpc/%s/ppcrossarm /usr/bin/ppcarm' % (fpcv)) != 0:
             return False


### PR DESCRIPTION
Reverts nielsAD/travis-lazarus#8

It seems `lazarus-project` is the new name for the `lazarus` package. Where previously both files were available for download, now only the project version remains.