### PR TITLE
fix homebrew build

### DIFF
--- a/.travis.install.py
+++ b/.travis.install.py
@@ -44,7 +44,7 @@ def install_osx_dmg(dmg):
 def install_lazarus_default():
     if OS_NAME == 'linux':
         # Make sure nogui is installed for headless runs
-        pkg = 'lazarus lcl-nogui'
+        pkg = 'lazarus lcl-nogui -y'
     elif OS_NAME == 'osx':
         # cask is already present in brew
         pkg = 'fpc && %s cask install fpcsrc lazarus' % (OS_PMAN)

--- a/.travis.install.py
+++ b/.travis.install.py
@@ -46,8 +46,8 @@ def install_lazarus_default():
         # Make sure nogui is installed for headless runs
         pkg = 'lazarus lcl-nogui'
     elif OS_NAME == 'osx':
-        # Install brew cask first
-        pkg = 'fpc caskroom/cask/brew-cask && %s cask install fpcsrc lazarus' % (OS_PMAN)
+        # cask is already present in brew
+        pkg = 'fpc && %s cask install fpcsrc lazarus' % (OS_PMAN)
     else:
         # Default to lazarus
         pkg = 'lazarus'

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ matrix:
       env: LAZ_VER=1.4.4  LAZ_ENV=qemu-arm LAZ_OPT="--os=linux --cpu=arm"
     - os: linux
       env: LAZ_VER=1.8.2 LAZ_ENV=qemu-arm LAZ_OPT="--os=linux --cpu=arm"
+    - os: linux
+      arch: arm64
+      env: LAZ_PKG=true
 
 before_install:
   # Start virtual display server


### PR DESCRIPTION
- Home brew build is now failing. It does not recognise 'caskroom/cask/brew-cask' any more. Fix: remove it.
- Try to test arm64 build failed because it is waiting for user input at apt get. Fix: add **-y** in apt
- Add arm64 in the build matrix. So lazarus user can experiment with this experimental arm64 build.

